### PR TITLE
Fix #3 - Renamed `pyqt5` backend to `pyqtgraph`.

### DIFF
--- a/bsl/commands/bsl_stream_viewer.py
+++ b/bsl/commands/bsl_stream_viewer.py
@@ -5,7 +5,7 @@ spectral filtering and common average filtering option.
 Command-line arguments:
     -s --stream_name    Stream name (str)
     -b --backend        Select plot backend (str).
-                        Supported: pyqt5, vispy
+                        Supported: pyqtgraph, vispy
 
 Example:
     bsl_stream_viewer
@@ -27,7 +27,7 @@ def run():
         help='stream to display/plot.')
     parser.add_argument(
         '-b', '--backend', type=str, metavar='str',
-        help='selected plot backend.', default='pyqt5')
+        help='selected plot backend.', default='pyqtgraph')
 
     args = parser.parse_args()
     stream_name = args.stream_name

--- a/bsl/stream_receiver/stream_receiver.py
+++ b/bsl/stream_receiver/stream_receiver.py
@@ -169,7 +169,7 @@ class StreamReceiver:
             self._acquisition_threads[stream] = thread
 
     @fill_doc
-    def get_window(self, stream_name=None, return_raw=False):
+    def get_window(self, stream_name=None, return_raw=False, verbose=True):
         """
         Get the latest window from a stream's buffer.
         If several streams are connected, specify the name.
@@ -178,6 +178,7 @@ class StreamReceiver:
         ----------
         %(receiver_get_stream_name)s
         %(receiver_get_return_raw)s
+        %(receiver_get_verbose)s
 
         Returns
         -------
@@ -236,16 +237,17 @@ class StreamReceiver:
                     f'The LSL stream {stream_name} can not be converted to'
                     'MNE raw instance. Returning numpy arrays.')
         else:
-            logger.warning(
-                f'The LSL stream {stream_name} did not return any data.'
-                'Returning empty numpy arrays.')
+            if verbose:
+                logger.warning(
+                    f'The LSL stream {stream_name} did not return any data.'
+                    'Returning empty numpy arrays.')
             window = np.empty((0, len(self._streams[stream_name].ch_list)))
             timestamps = np.array([])
 
         return window, timestamps
 
     @fill_doc
-    def get_buffer(self, stream_name=None, return_raw=False):
+    def get_buffer(self, stream_name=None, return_raw=False, verbose=True):
         """
         Get the entire buffer of a stream.
         If several streams are connected, specify the name.
@@ -254,6 +256,7 @@ class StreamReceiver:
         ----------
         %(receiver_get_stream_name)s
         %(receiver_get_return_raw)s
+        %(receiver_get_verbose)s
 
         Returns
         -------
@@ -298,9 +301,10 @@ class StreamReceiver:
                     f'The LSL stream {stream_name} can not be converted to'
                     'MNE raw instance. Returning numpy arrays.')
         else:
-            logger.warning(
-                f'The LSL stream {stream_name} did not return any data.'
-                'Returning empty numpy arrays.')
+            if verbose:
+                logger.warning(
+                    f'The LSL stream {stream_name} did not return any data.'
+                    'Returning empty numpy arrays.')
             window = np.empty((0, len(self._streams[stream_name].ch_list)))
             timestamps = np.array([])
 

--- a/bsl/stream_viewer/__init__.py
+++ b/bsl/stream_viewer/__init__.py
@@ -3,32 +3,6 @@ Module for signal visualization.
 
 Visualize signals in real time with spectral filtering, common average
 filtering options and real-time FFT.
-
-TODO:
-    ScopeController:
-        - Add Key Press Events (Close, Pause, ...)
-        - Add Key triggers
-        - Add a trigger selection to allow Key trigger to be saved in the
-        recorded file.
-        - Reorganize / Improve GUI.
-
-    Vispy backend:
-        - Add channels names + axis labels
-        - Add trigger events (Common _TriggerEvent class for every backends?)
-        - Fix position when creating the window
-        - Fix the non-fatal errors raised.
-
-    PyQt5 backend:
-        - Subsampling doesn't look needed for 64 channels@512 Hz. Set a dynamic
-        application of subsampling based on number of channels and sample rate.
-        - Fix position when creating the graphic window
-
-    PyQt6 backend:
-        - Is there an upgrade to be done from PyQt5?
-
-    - Set the nrows, ncols parameter for every backend based on the number of
-    channels. e.g. 128 channels system could be displayed on 2 columns of 64
-    channels.
 """
 
 from .stream_viewer import StreamViewer

--- a/bsl/stream_viewer/backends/pyqtgraph.py
+++ b/bsl/stream_viewer/backends/pyqtgraph.py
@@ -13,9 +13,9 @@ from ...utils._docs import fill_doc, copy_doc
 
 
 @fill_doc
-class _BackendPyQt5(_Backend):
+class _BackendPyQtGraph(_Backend):
     """
-    The PyQt5 backend for BSL's `StreamViewer`.
+    PyQtGraph backend for BSL's `StreamViewer`.
 
     Parameters
     ----------
@@ -228,7 +228,7 @@ class _BackendPyQt5(_Backend):
 @fill_doc
 class _TriggerEvent(_Event):
     """
-    Class defining a trigger event for the pyqt5 backend.
+    Class defining a trigger event for the pyqtgraph backend.
 
     Parameters
     ----------

--- a/bsl/stream_viewer/control_gui/_control.py
+++ b/bsl/stream_viewer/control_gui/_control.py
@@ -8,7 +8,7 @@ try:
     from ..backends.vispy import _BackendVispy
 except ModuleNotFoundError:
     pass
-from ..backends.pyqt5 import _BackendPyQt5
+from ..backends.pyqtgraph import _BackendPyQtGraph
 
 from ... import logger
 from ...utils._docs import fill_doc
@@ -103,16 +103,16 @@ class _ControlGUI(QMainWindow, ABC, metaclass=_metaclass_ControlGUI):
         """
         Checks that the requested backend is supported.
         """
-        DEFAULT = ['pyqt5', 'vispy']  # Default order
+        DEFAULT = ['pyqtgraph', 'vispy']  # Default order
         SUPPORTED_BACKENDS = dict()
         try:
             SUPPORTED_BACKENDS['vispy'] = _BackendVispy
         except NameError:
             SUPPORTED_BACKENDS['vispy'] = None
         try:
-            SUPPORTED_BACKENDS['pyqt5'] = _BackendPyQt5
+            SUPPORTED_BACKENDS['pyqtgraph'] = _BackendPyQtGraph
         except NameError:
-            SUPPORTED_BACKENDS['pyqt5'] = None
+            SUPPORTED_BACKENDS['pyqtgraph'] = None
         assert set(DEFAULT) == set(SUPPORTED_BACKENDS)
 
         if all(backend is None for backend in SUPPORTED_BACKENDS.values()):

--- a/bsl/stream_viewer/scope/_scope.py
+++ b/bsl/stream_viewer/scope/_scope.py
@@ -57,7 +57,7 @@ class _Scope(ABC):
         Acquires data from the connected LSL stream.
         """
         self._sr.acquire()
-        self._data_acquired, self._ts_list = self._sr.get_buffer()
+        self._data_acquired, self._ts_list = self._sr.get_buffer(verbose=False)
         self._sr.reset_buffer()
 
         if len(self._ts_list) > 0:

--- a/bsl/stream_viewer/stream_viewer.py
+++ b/bsl/stream_viewer/stream_viewer.py
@@ -17,7 +17,7 @@ class StreamViewer:
     performed followed by a prompt if multiple non-markers streams are found.
 
     Supports 2 backends:
-        - ``'pyqt5'``: fully functional.
+        - ``'pyqtgraph'``: fully functional.
         - ``'vispy'``: in progress.
 
     Parameters
@@ -30,7 +30,7 @@ class StreamViewer:
     def __init__(self, stream_name=None):
         self._stream_name = StreamViewer._check_stream_name(stream_name)
 
-    def start(self, bufsize=0.2, backend='pyqt5'):
+    def start(self, bufsize=0.2, backend='pyqtgraph'):
         """
         Connect to the selected amplifier and plot the streamed data.
 
@@ -44,7 +44,7 @@ class StreamViewer:
             ``0.2`` should work in most cases.
         backend : str
             Selected backend for plotting. Supports:
-                - ``'pyqt5'``: fully functional.
+                - ``'pyqtgraph'``: fully functional.
                 - ``'vispy'``: in progress.
         """
         backend = StreamViewer._check_backend(backend)

--- a/bsl/utils/_docs.py
+++ b/bsl/utils/_docs.py
@@ -27,6 +27,10 @@ return_raw : bool
     By default (False), data is returned as a numpy array of shape
     (samples, channels). If set to True, the stream receiver will attempt to
     return MNE raw instances."""
+docdict['receiver_get_verbose'] = """
+verbose : bool
+    If True (default), a warning will be issued when the method returns empty
+    arrays. If False, this warning will be skipped."""
 docdict['receiver_data'] = """
 data : np.array
      Data ``[samples x channels]``."""

--- a/bsl/utils/_docs.py
+++ b/bsl/utils/_docs.py
@@ -108,7 +108,8 @@ docdict['viewer_backend_yRange'] = """yRange : float
     Range of the y-axis (amplitude) in uV."""
 docdict['viewer_backend'] = """
 backend : str
-    One of the supported backend's name. Supported ``'vispy'``, ``'pyqt5'``."""
+    One of the supported backend's name. Supported ``'vispy'``,
+    ``'pyqtgraph'``."""
 docdict['viewer_scope_stream_receiver'] = """
 stream_receiver : StreamReceiver
     Connected `StreamReceiver`."""


### PR DESCRIPTION
Fix #3.

The backend name has been changed to `pyqtgraph`.
The StreamViewer verbosity has been reduced by removing the `.get_buffer()` warning when an empty array is returned by the StreamReceiver.