### PR TITLE
Set pins to 0 during initialization of the parallel port

### DIFF
--- a/bsl/triggers/parallel.py
+++ b/bsl/triggers/parallel.py
@@ -85,7 +85,7 @@ class ParallelPortTrigger(BaseTrigger):
             self._address = address
             self._connect_pport()
 
-        self._offtimer = threading.Timer(self._delay, self._signal_off)
+        self._signal_off()  # set pins to 0 and define self._offtimer
 
     @staticmethod
     def _infer_port_type(address: Union[int, str]) -> str:


### PR DESCRIPTION
Spotted on Windows today, the ParallelPort has one pin that was active by default.
For safety, let's set them to 0 during init.